### PR TITLE
Control base LLM and add San Marino

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ def main():
         vectorstorage_path=os.path.join(
             os.path.dirname(__file__), "data", "special_coins.npz"
         ),
-        base_llm="mlabonne/NeuralHermes-2.5-Mistral-7B"
+        base_llm="meta-llama/Meta-Llama-3-70B-Instruct"
     )
     bot.run()
 

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ def main():
         vectorstorage_path=os.path.join(
             os.path.dirname(__file__), "data", "special_coins.npz"
         ),
-        base_llm="meta-llama/Meta-Llama-3-8B-Instruct"
+        base_llm="mlabonne/NeuralHermes-2.5-Mistral-7B"
     )
     bot.run()
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ def main():
         vectorstorage_path=os.path.join(
             os.path.dirname(__file__), "data", "special_coins.npz"
         ),
+        base_llm="meta-llama/Meta-Llama-3-8B-Instruct"
     )
     bot.run()
 

--- a/coinbot/core.py
+++ b/coinbot/core.py
@@ -53,7 +53,7 @@ class CoinBot:
         anyscale_token: str,
         slack_token: str,
         vectorstorage_path: str,
-        base_llm: str="meta-llama/Meta-Llama-3-8B-Instruct"
+        base_llm: str = "meta-llama/Meta-Llama-3-8B-Instruct",
     ):
         # Load tokens and initialize variables
         self.telegram_token = telegram_token
@@ -84,7 +84,6 @@ class CoinBot:
         self.public_link = public_link
         self.fetch_file(link=public_link)
         self.db = DataBase(self.filepath)
-
         self.vectorstorage_path = vectorstorage_path
         self.vectorstorage = VectorStorage.load(vectorstorage_path)
 
@@ -414,6 +413,7 @@ class CoinBot:
                 value += " cent"
 
         year = get_feature_value(llm_output, "year")
+        logger.debug(f"Raw features {c}, {value}, {year}")
         try:
             year = int(year)
         except ValueError:
@@ -685,8 +685,6 @@ class CoinBot:
         self.to_english_llm = LLM(
             model=self.base_llm,
             token=self.anyscale_token,
-            task_prompt=(
-                "Give me the ENGLISH name of this country. Be concise, only one word."
-            ),
+            task_prompt=("Give me the ENGLISH name of this country. Be concise!"),
             temperature=0.0,
         )

--- a/coinbot/core.py
+++ b/coinbot/core.py
@@ -53,10 +53,12 @@ class CoinBot:
         anyscale_token: str,
         slack_token: str,
         vectorstorage_path: str,
+        base_llm: str="meta-llama/Meta-Llama-3-8B-Instruct"
     ):
         # Load tokens and initialize variables
         self.telegram_token = telegram_token
         self.anyscale_token = anyscale_token
+        self.base_llm = base_llm
 
         # Initialize language preferences dictionary
         self.user_prefs = defaultdict(dict)
@@ -658,13 +660,13 @@ class CoinBot:
 
     def set_llms(self):
         self.eu_llm = LLM(
-            model="meta-llama/Meta-Llama-3-8B-Instruct",
+            model=self.base_llm,
             token=self.anyscale_token,
             task_prompt="You are a feature extractor! Extract 3 features, Country, coin value (in euro or cents) and year. Never give the coin value in fractional values, use 10 cent rather than 0.1 euro. Use a colon (:) before each feature value. If one of the three features is missing reply simply with `Missing feature`. Be concise and efficient!",
             temperature=0.0,
         )
         self.ger_llm = LLM(
-            model="meta-llama/Meta-Llama-3-8B-Instruct",
+            model=self.base_llm,
             token=self.anyscale_token,
             task_prompt=(
                 "You are a feature extractor! Extract 4 features, Country, coin value (in euro or cents), year and source. The source is given as single character, A, D, F, G or J. Never give the coin value in fractional values, use 10 cent rather than 0.1 euro. If one of the three features is missing reply simply with `Missing feature`. Do not overlook the source!"
@@ -673,7 +675,7 @@ class CoinBot:
             temperature=0.0,
         )
         self.joke_llm = LLM(
-            model="meta-llama/Meta-Llama-3-8B-Instruct",
+            model=self.base_llm,
             token=self.anyscale_token,
             task_prompt=(
                 "Tell me a very short joke about the following coin. Start with `Here's a funny story about your coin:`"
@@ -681,7 +683,7 @@ class CoinBot:
             temperature=0.6,
         )
         self.to_english_llm = LLM(
-            model="meta-llama/Meta-Llama-3-8B-Instruct",
+            model=self.base_llm,
             token=self.anyscale_token,
             task_prompt=(
                 "Give me the ENGLISH name of this country. Be concise, only one word."

--- a/coinbot/llm.py
+++ b/coinbot/llm.py
@@ -1,6 +1,7 @@
+import re
+
 import numpy as np
 import openai
-import re
 
 INSTRUCTION_MESSAGE = """
 I'm helping you to identify & collect **rare** EURO coins. Just ask me about a coin. I always need the value, the country and the year of the coin. I will let you know how many times the coin was minted and if it's already available in Jannis' coin collection. 
@@ -70,17 +71,12 @@ class LLM:
 
         # Process and stream the response.
         response_content = ""
-        first_token = True
         self.counter += 1
 
         for token in response:
             delta = token.choices[0].delta.content
-            if first_token:
-                # Skip first token to unblock response.
-                first_token = False
-                continue
-            elif not delta:
-                # End token indicating the end of the response.
+            # End token indicating the end of the response.
+            if token.choices[0].finish_reason:
                 self._add_to_message_history("assistant", response_content)
                 break
             else:

--- a/coinbot/metadata.py
+++ b/coinbot/metadata.py
@@ -37,14 +37,16 @@ eurozone = [
     "Netherlands",
     "Austria",
     "Portugal",
+    "San Marino",
     "Slovakia",
     "Slovenia",
     "Spain",
     "Cyprus",
+    "Vatican",
 ]
 
 # To include countries that use the Euro but are not part of the Eurozone, you might add:
-euro_users = ["Monaco", "Vatican", "Andorra"]
+euro_users = ["Monaco", "Andorra"]
 country_eng2ger = {
     "Andorra": "Andorra",
     "Belgium": "Belgien",


### PR DESCRIPTION
- Closes #25 
- Allows to control what is the base LLM from outside, defaults to Llama 3 but currently we use "mlabonne/NeuralHermes-2.5-Mistral-7B" since it's more stable
- Fixes a bug in model readout where the entire output was truncated